### PR TITLE
Hide headers to fix duplicates in published version.

### DIFF
--- a/workshop/content/_index.en.md
+++ b/workshop/content/_index.en.md
@@ -5,7 +5,9 @@ weight = 1
 +++
 
 
+<!-- TODO: Temporarily fixing duplicate headers in chapters on published workshop. Note: This hides header from local build.
 # AWS Nitro Enclaves Workshop
+-->
 
 ![AWS Nitro Enclaves Splash Image](/images/nitro-enclaves.png?featherlight=false)
 

--- a/workshop/content/cleanup/_index.en.md
+++ b/workshop/content/cleanup/_index.en.md
@@ -1,10 +1,14 @@
 +++
-title = "Cleanup"
+linkTitle = "Cleanup"
+title = "Workshop Cleanup"
 weight = 200
 chapter = true
 +++
 
+
+<!-- TODO: Temporarily fixing duplicate headers in chapters on published workshop. Note: This hides header from local build.
 # Workshop Cleanup
+-->
 
 ### Thank you for exploring the AWS Nitro Enclaves workshop!
 ---

--- a/workshop/content/my-first-enclave/_index.en.md
+++ b/workshop/content/my-first-enclave/_index.en.md
@@ -5,7 +5,9 @@ weight = 20
 +++
 
 
+<!-- TODO: Temporarily fixing duplicate headers in chapters on published workshop. Note: This hides header from local build.
 # My First Enclave
+-->
 
 {{% youtube tRL7Y0mJqU4 %}}
 


### PR DESCRIPTION
*Description of changes:*
Commenting out headers on chapters to fix published version which used a modified/customized theme. Also, made use of `linkTitle` attribute in front matter for a chapter page on which prefer a different header vs. menu name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
