### PR TITLE
Create a shallow clone with the latest commit.

### DIFF
--- a/workshop/content/getting-started/prerequisites.en.md
+++ b/workshop/content/getting-started/prerequisites.en.md
@@ -85,7 +85,7 @@ For additional details, see [Documentation](https://docs.aws.amazon.com/enclaves
 
 1. Use `git clone` to download a copy of this workshop's repository. This repo includes the content used in subsequent modules.
     ```sh
-    $ git clone https://github.com/aws-samples/aws-nitro-enclaves-workshop.git
+    $ git clone --depth 1 https://github.com/aws-samples/aws-nitro-enclaves-workshop.git
     ```
 
 ---


### PR DESCRIPTION
*Description of changes:*
Add `--depth 1` to ensure a shallow clone is create with only the latest commit. This will reduce amount of data being transferred since history isn't really necessary as part of the execution of the workshop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
