### PR TITLE
Update cryptographic attestation sample

### DIFF
--- a/resources/code/my-first-enclave/cryptographic-attestation/server.py
+++ b/resources/code/my-first-enclave/cryptographic-attestation/server.py
@@ -46,7 +46,7 @@ def decrypt_cipher(access, secret, token, ciphertext, region):
 
     if ret[0]:
         b64text = proc.communicate()[0].decode()
-        plaintext = json.loads(base64.b64decode(b64text))
+        plaintext = base64.b64decode(b64text).decode()
         return plaintext
     else:
         return "KMS Error. Decryption Failed."
@@ -74,7 +74,7 @@ def main():
         if plaintext == "KMS Error. Decryption Failed.":
             r["error"] = plaintext
         else:
-            last_four = str(plaintext)[-4:]
+            last_four = plaintext[-4:]
             r["last_four"] = last_four
 
         c.send(str.encode(json.dumps(r)))

--- a/workshop/content/my-first-enclave/cryptographic-attestation/_index.en.md
+++ b/workshop/content/my-first-enclave/cryptographic-attestation/_index.en.md
@@ -334,7 +334,7 @@ So far in this section, you've explored the base functionality of this sensitive
 The enclave application file `server.py` contains the following code:
 
 ```python {linenos=true, linenostart=77}
-    last_four = str(plaintext)[-4:]
+    last_four = plaintext[-4:]
     r["last_four"] = last_four
 
 c.send(str.encode(json.dumps(r)))
@@ -351,7 +351,7 @@ $ sed -i "s|\[-4:\]||" ./server.py
 After running this command `server.py` will now look like this:
 
 ```python {linenos=true, hl_lines=[1] linenostart=77}
-    last_four = str(plaintext)
+    last_four = plaintext
     r["last_four"] = last_four
 
 c.send(str.encode(json.dumps(r)))


### PR DESCRIPTION
Accommodating both integers and strings for sample values.

*Issue #, if available:* #24

*Description of changes:* Tweaked cryptographic attestation sample to better accommodate both integer and string sample values.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
