### PR TITLE
Update base image dependencies

### DIFF
--- a/resources/code/getting-started/Dockerfile
+++ b/resources/code/getting-started/Dockerfile
@@ -18,7 +18,7 @@ RUN yum install -y quilt
 # We keep the build artifacts in the -build directory
 WORKDIR /tmp/crt-builder
 
-RUN git clone --depth 1 --b v0.2.0  https://github.com/aws/aws-nitro-enclaves-sdk-c
+RUN git clone --depth 1 -b v0.2.0  https://github.com/aws/aws-nitro-enclaves-sdk-c
 
 RUN git clone -b v0.0.2 https://github.com/awslabs/aws-lc.git aws-lc #
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-lc -B aws-lc/build .


### PR DESCRIPTION
*Issue #, if available:* #29

*Description of changes:* Updated enclave base image dependencies. Explicitly targeting aws-nitro-enclaves-sdk-c v0.2.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
