### PR TITLE
Fix incorrect naming in get_account() return

### DIFF
--- a/resources/code/my-first-enclave/cryptographic-attestation/client.py
+++ b/resources/code/my-first-enclave/cryptographic-attestation/client.py
@@ -57,8 +57,8 @@ def get_account(identity):
     """
     Get account of current instance identity
     """
-    region = identity.json()["accountId"]
-    return region
+    account = identity.json()["accountId"]
+    return account
 
 
 def set_identity():


### PR DESCRIPTION
This is a very small fix for readability.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
