### PR TITLE
Fix path to vsock_proxy config

### DIFF
--- a/workshop/content/my-first-enclave/secure-local-channel/_index.en.md
+++ b/workshop/content/my-first-enclave/secure-local-channel/_index.en.md
@@ -114,12 +114,12 @@ Before going to the next module, please stop existing Nitro Enclaves and restart
 
 1. On the terminal session with `vsock-proxy`, press `CTRL+C (^C)` to stop `vsock-proxy` that running with your custom config.
 
-1. Start `vsock-proxy` as a service with default configuration from `/etc/vsock_proxy/config.yaml` by executing the following commands:
+1. Start `vsock-proxy` as a service with default configuration from `/etc/nitro_enclaves/vsock-proxy.yaml` by executing the following commands:
     ```sh
     $ sudo systemctl enable nitro-enclaves-vsock-proxy.service
     $ sudo systemctl start nitro-enclaves-vsock-proxy.service
     ```
-The proxy will now run using the default configuration from `/etc/vsock_proxy/config.yaml`, on local port `8000`, and proxying to the AWS KMS endpoint corresponding to the instance's AWS Region.
+The proxy will now run using the default configuration from `/etc/nitro_enclaves/vsock-proxy.yaml`, on local port `8000`, and proxying to the AWS KMS endpoint corresponding to the instance's AWS Region.
 
 ---
 #### Proceed to the [Cryptographic attestation](cryptographic-attestation.html) section to continue the workshop.


### PR DESCRIPTION
The path to the `vsock_proxy` config file given in the workshop is incorrect; the configuration file is in `/etc/nitro_enclaves` much like for the allocator, as seen in

```
$ systemctl cat nitro-enclaves-vsock-proxy.service 
# /usr/lib/systemd/system/nitro-enclaves-vsock-proxy.service
[Unit]
Description=Nitro Enclaves vsock Proxy
After=network-online.target
DefaultDependencies=no

[Service]
Type=simple
StandardOutput=journal
StandardError=journal
SyslogIdentifier=vsock-proxy
ExecStart=/bin/bash -ce "TOKEN=$(curl --silent -X PUT \"http://169.254.169.254/latest/api/token\" -H 
                        REGION=$(curl --silent -H \"X-aws-ec2-metadata-token: $TOKEN\" http://169.254
                        [ -z \"$REGION\" ] && REGION=$(curl --silent http://169.254.169.254/latest/dy
                        exec /usr/bin/vsock-proxy 8000 kms.$${REGION}.amazonaws.com 443 \
                --config /etc/nitro_enclaves/vsock-proxy.yaml"
Restart=always
TimeoutSec=0
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
