### PR TITLE
upgrade rust to nightly

### DIFF
--- a/resources/code/getting-started/Dockerfile
+++ b/resources/code/getting-started/Dockerfile
@@ -62,7 +62,7 @@ RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_L
 RUN cmake3 --build json-c/build --target install
 
 RUN git clone -b v0.1.0 https://github.com/aws/aws-nitro-enclaves-nsm-api.git
-RUN source $HOME/.cargo/env && cd aws-nitro-enclaves-nsm-api && cargo build --release -p nsm-lib
+RUN source $HOME/.cargo/env && rustup default nightly && rustup update && cd aws-nitro-enclaves-nsm-api && cargo build --release -p nsm-lib
 RUN mv aws-nitro-enclaves-nsm-api/target/release/libnsm.so /usr/lib64
 RUN mv aws-nitro-enclaves-nsm-api/target/release/nsm.h /usr/include
 


### PR DESCRIPTION
`docker build ./ -t "enclave_base"` fails with following error.
this commit fixes the issue.

```

Step 44/55 : RUN git clone -b v0.1.0 https://github.com/aws/aws-nitro-enclaves-nsm-api.git
 ---> Using cache
 ---> 1c80ff93976e
Step 45/55 : RUN source $HOME/.cargo/env && cd aws-nitro-enclaves-nsm-api && cargo build --release -p nsm-lib
 ---> Running in 894471dccbff
    Updating crates.io index
 Downloading crates ...
  Downloaded fastrand v1.9.0
  Downloaded io-lifetimes v1.0.9
  Downloaded half v1.8.2
  Downloaded toml v0.5.11
  Downloaded cfg-if v0.1.10
  Downloaded log v0.4.17
  Downloaded bitflags v1.3.2
  Downloaded unicode-ident v1.0.8
  Downloaded quote v1.0.26
  Downloaded serde_derive v1.0.159
  Downloaded serde v1.0.159
  Downloaded serde_json v1.0.95
  Downloaded cbindgen v0.14.3
  Downloaded syn v2.0.11
error: failed to parse manifest at `/root/.cargo/registry/src/github.com-1ecc6299db9ec823/syn-2.0.11/Cargo.toml`

Caused by:
  feature `edition2021` is required

  The package requires the Cargo feature called `edition2021`, but that feature is not stabilized in this version of Cargo (1.55.0 (32da73ab1 2021-08-23)).
  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2021 for more information about the status of this feature.
The command '/bin/sh -c source $HOME/.cargo/env && cd aws-nitro-enclaves-nsm-api && cargo build --release -p nsm-lib' returned a non-zero code: 101
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
