### PR TITLE
Increment rust default toolchain to 1.60

### DIFF
--- a/resources/code/getting-started/Dockerfile
+++ b/resources/code/getting-started/Dockerfile
@@ -8,7 +8,7 @@ RUN yum upgrade -y
 RUN amazon-linux-extras enable epel
 RUN yum clean -y metadata && yum install -y epel-release
 RUN yum install -y cmake3 gcc git tar make
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.55
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.60
 
 RUN yum install -y gcc-c++
 RUN yum install -y go


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Make the rust default tool chain version same as the one used in Nitro Enclaves C SDK v0.2.1 ~/containers/Dockerfile.al2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
