### PR TITLE
Pin urllib3 version to avoid conflicts with botocore

### DIFF
--- a/resources/code/my-first-enclave/cryptographic-attestation/requirements.txt
+++ b/resources/code/my-first-enclave/cryptographic-attestation/requirements.txt
@@ -2,3 +2,4 @@
 # // SPDX-License-Identifier: MIT-0
 requests==2.31.0
 boto3==1.17.81
+urllib3==1.26.16


### PR DESCRIPTION

*Issue #, if available: None

*Description of changes: botocore needs an older version of urllib3 compared to what requests library brings in as dependency. Pinning the urllib3 version to avoid conflicts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
